### PR TITLE
Add info method to the new console to fix #5 issue

### DIFF
--- a/consolewrapper.js
+++ b/consolewrapper.js
@@ -32,6 +32,17 @@ var newConsole = (function(oldConsole)
                 oldConsole.log(data[0], data.splice(1));
             return null;
         },
+        info : function()
+        {
+            var data = [];
+            for (var _i = 0; _i < arguments.length; _i++) {
+                data[_i] = arguments[_i];
+            }
+            if(data.length == 1)
+                oldConsole.info(data[0]);
+            else
+                oldConsole.info(data[0], data.splice(1));
+        },
         warn : function()
         {
             var data = [];


### PR DESCRIPTION
Simple fix for #5 issue, where `newConsole.info` function was called from `game.js` but failed due to it being not defined.